### PR TITLE
[label] Add: workflow for gssoc auto label

### DIFF
--- a/.github/workflows/autoLabel.yml
+++ b/.github/workflows/autoLabel.yml
@@ -1,0 +1,13 @@
+name: Labeling new issue
+on:
+  issues:
+    types: ['opened']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: true
+          labels-synonyms: '{"GSSOC21":["GSSOC","GSSOC21","gssoc","Gssoc","GSSoC"]}'


### PR DESCRIPTION
closes #31

# Description:
Added workflow for auto `GSSOC21` label to newly created issues.



- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

 